### PR TITLE
Make Preference classes implement relevant Supplier interfaces

### DIFF
--- a/src/main/java/org/hyperonline/hyperlib/pref/BooleanPreference.java
+++ b/src/main/java/org/hyperonline/hyperlib/pref/BooleanPreference.java
@@ -2,12 +2,14 @@ package org.hyperonline.hyperlib.pref;
 
 import edu.wpi.first.wpilibj.Preferences;
 
+import java.util.function.BooleanSupplier;
+
 /**
  * A class which represents a boolean-valued preference
  *
  * @author James Hagborg
  */
-public class BooleanPreference extends Preference {
+public class BooleanPreference extends Preference implements BooleanSupplier {
   private final boolean m_default;
   private boolean m_lastValue;
 
@@ -47,5 +49,10 @@ public class BooleanPreference extends Preference {
    */
   public boolean get() {
     return Preferences.getBoolean(getName(), m_default);
+  }
+
+  @Override
+  public boolean getAsBoolean() {
+    return this.get();
   }
 }

--- a/src/main/java/org/hyperonline/hyperlib/pref/DoublePreference.java
+++ b/src/main/java/org/hyperonline/hyperlib/pref/DoublePreference.java
@@ -2,12 +2,14 @@ package org.hyperonline.hyperlib.pref;
 
 import edu.wpi.first.wpilibj.Preferences;
 
+import java.util.function.DoubleSupplier;
+
 /**
  * A class which represents a double-valued preference
  *
  * @author James Hagborg
  */
-public class DoublePreference extends Preference {
+public class DoublePreference extends Preference implements DoubleSupplier {
   private final double m_default;
   private double m_lastValue;
 
@@ -47,5 +49,10 @@ public class DoublePreference extends Preference {
    */
   public double get() {
     return Preferences.getDouble(getName(), m_default);
+  }
+
+  @Override
+  public double getAsDouble() {
+    return this.get();
   }
 }

--- a/src/main/java/org/hyperonline/hyperlib/pref/IntPreference.java
+++ b/src/main/java/org/hyperonline/hyperlib/pref/IntPreference.java
@@ -2,12 +2,14 @@ package org.hyperonline.hyperlib.pref;
 
 import edu.wpi.first.wpilibj.Preferences;
 
+import java.util.function.IntSupplier;
+
 /**
  * A class which represents an integer-valued preference
  *
  * @author James Hagborg
  */
-public class IntPreference extends Preference {
+public class IntPreference extends Preference implements IntSupplier {
   private final int m_default;
   private int m_lastValue;
 
@@ -47,5 +49,10 @@ public class IntPreference extends Preference {
    */
   public int get() {
     return Preferences.getInt(getName(), m_default);
+  }
+
+  @Override
+  public int getAsInt() {
+    return this.get();
   }
 }

--- a/src/main/java/org/hyperonline/hyperlib/pref/ScalarPreference.java
+++ b/src/main/java/org/hyperonline/hyperlib/pref/ScalarPreference.java
@@ -4,13 +4,14 @@ import org.opencv.core.Scalar;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * {@link ScalarPreference}
  *
  * @author James
  */
-public class ScalarPreference {
+public class ScalarPreference implements Supplier<Scalar> {
 
   private List<DoublePreference> m_prefs = new ArrayList<>();
 
@@ -50,6 +51,7 @@ public class ScalarPreference {
    *
    * @return The current value of the preference.
    */
+  @Override
   public Scalar get() {
     return new Scalar(m_prefs.stream().mapToDouble(DoublePreference::get).toArray());
   }

--- a/src/main/java/org/hyperonline/hyperlib/pref/StringPreference.java
+++ b/src/main/java/org/hyperonline/hyperlib/pref/StringPreference.java
@@ -2,12 +2,14 @@ package org.hyperonline.hyperlib.pref;
 
 import edu.wpi.first.wpilibj.Preferences;
 
+import java.util.function.Supplier;
+
 /**
  * A class which represents a string-valued preference
  *
  * @author James Hagborg
  */
-public class StringPreference extends Preference {
+public class StringPreference extends Preference implements Supplier<String> {
   private final String m_default;
   private String m_lastValue;
 
@@ -50,6 +52,7 @@ public class StringPreference extends Preference {
    * @return The value of the preference
    * @see Preferences#getString(String, String)
    */
+  @Override
   public String get() {
     return Preferences.getString(getName(), m_default);
   }


### PR DESCRIPTION
This PR makes `IntPreference`, `DoublePreference`, etc. implement `IntSupplier` and `DoubleSupplier`, etc. respectively.
Also makes `StringPreference` and `ScalarPreference` implement `Supplier<String>` and `Supplier<Scalar>`.

This should make using it in robot code slightly easier, not needing to use `preference::get` each time a supplier is required.